### PR TITLE
[fix] logic for iterative factorial function #6

### DIFF
--- a/Maths/factorial/factorial.sol
+++ b/Maths/factorial/factorial.sol
@@ -11,7 +11,7 @@ contract Factorial {
     function factoIterative(int _n) public pure returns (int) {
         int result= 1;
 
-        for (uint i= 2; i >= _n; i++){
+        for (int i= 2; i <= _n; ++i){
             result *= i;
         }
 


### PR DESCRIPTION
This PR provides the fix for the issue #6 

- Fixed the conditional checks for the uint and int type comparison
- Fixed the condition where i should be <= _n
- Also saved some gas for the iterative function by using pre-increment operator (++i)

**Gas Comparison**

| Operation |      Execution Cost      | 
|:----------:|:-------------:|
| i++|  26496 gas | 
| ++i |   26456 gas   |   