### PR TITLE
[pattern]: add emergencyStop solidity pattern + readme

### DIFF
--- a/EmergencyStop/README.md
+++ b/EmergencyStop/README.md
@@ -1,0 +1,17 @@
+# Emergency Stop pattern
+
+This model incorporates the possibility of suspending the execution of all the functions in the contract in the event of a problem. Since contracts are immutable once deployed; if there are bugs in the contract, the `pause` feature can be activated to prevent further damage.
+
+The emergency pause functionality must be under the control of the owner or an authorized address. **The emergency shutdown model** should be avoided at all costs as it goes against the spirit of decentralization, but in cases where centralized control is required, it could be a valid model to include in your contract.
+
+## Contract informations
+
+Access modifiers are used to restrict access. The contract has a function called `depositEther` which can only be called when the function is not in a paused state. The pause state can be activated by the contract owner and when the contract is paused users can no longer deposits ether.
+
+The contract also has an `emergencyWithdrawal` function that can be triggered by the owner if the contract is paused as a result of bugs in the code and the ether in the contract can safely be transferred elsewhere.
+
+## When to use
+
+- You want the ability to pause the contract as a result of unwanted situation
+- In case of failure you want the ability to stop state corruption.
+- You are a centralized entity.

--- a/EmergencyStop/emergencyStop.sol
+++ b/EmergencyStop/emergencyStop.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+/**
+ * @title Solidity Emergency Stop pattern
+ *
+ * This is a pattern to stop the contract execution.
+ * MerchantBank is the owner of the contract is the person that deploys it.
+ *
+ */
+contract MerchantBank {
+    address payable public owner;
+    bool paused = false;
+
+    constructor() {
+        owner = payable(msg.sender);
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    modifier isPaused() {
+        require(paused);
+        _;
+    }
+
+    modifier notPaused() {
+        require(!paused);
+        _;
+    }
+
+    function pauseContract() public onlyOwner notPaused {
+        paused = true;
+    }
+
+    function unpauseContract() public onlyOwner isPaused {
+        paused = false;
+    }
+
+    function depositEther() public notPaused {
+        // logic to deposit ether into the contract
+    }
+
+    /** @notice transfer the ether out fast before more damage is done.
+     *
+     */
+    function emergencyWithdrawal() public isPaused {
+        owner.transfer(address(this).balance);
+    }
+}

--- a/EmergencyStop/emergencyStop.sol
+++ b/EmergencyStop/emergencyStop.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.10;
  * @title Solidity Emergency Stop pattern
  *
  * This is a pattern to stop the contract execution.
- * MerchantBank is the owner of the contract is the person that deploys it.
+ * Contract MerchantBank which the owner of the contract is the person that deploys it.
  *
  */
 contract MerchantBank {


### PR DESCRIPTION
Adding EmergencyStop Solidity pattern.

# EmergencyStop pattern

This model incorporates the possibility of suspending the execution of all the functions in the contract in the event of a problem. Since contracts are immutable once deployed; if there are bugs in the contract, the `pause` feature can be activated to prevent further damage.

The emergency pause functionality must be under the control of the owner or an authorized address. **The emergency stop pattern** should be avoided at all costs as it goes against the spirit of decentralization, but in cases where centralized control is required, it could be a valid model to include in your contract.

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/Solidity/pull/16"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

