### PR TITLE
fix: remove Foundry extension ` is Test` from contract

### DIFF
--- a/src/Sorts/BubbleSort.sol
+++ b/src/Sorts/BubbleSort.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "forge-std/Test.sol";
-
 /**
  * @title Get the absolute value of an integer.
  * @author Perelyn https://github.com/Perelyn-sama
  * @dev https://www.khanacademy.org/math/cc-sixth-grade-math/cc-6th-negative-number-topic/cc-6th-absolute-value/v/absolute-value-of-integers
  */
-contract BubbleSort is Test {
+contract BubbleSort {
     function bubbleSort(uint256[] memory _arr)
         public
         pure


### PR DESCRIPTION
# Description

Remove the `is Test` extension of [Foundry](https://book.getfoundry.sh/) from the smart contract.

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/Solidity/pull/31"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

