### PR TITLE
added list of algorithms to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,37 @@ This is going to be used for our partnership with [Dev Protocol](https://devprot
 
 Implementations are for learning purposes only. As they may be less secure than in real-world context, use them at your discretion.
 
-## Community Channels
+## Lists of Algorithms-
+
+* [Algorithms](./src)
+  * [Maths](./src/Maths)
+    * [Abs](./src/Maths/Abs.sol)
+    * [AddArray](./src/Maths/AddArray.sol)
+    * [AliquotSum](./src/Maths/AliquotSum.sol)
+    * [Area](./src/Maths/Area.sol)
+    * [Armstrong Number](./src/Maths/armstrongNumber.sol)
+    * [Average Mean](./src/Maths/AverageMean.sol)
+    * [Divide Digit](./src/Maths/divideDigit.sol)
+    * [Exponentiation](./src/Maths/exponentiation.sol)
+    * [Factorial](./src/Maths/factorial.sol)
+    * [Fibonacci](./src/Maths/fibonacci.sol)
+    * [Lucas Series](./src/Maths/lucasSeries.sol)
+    * [Modulo](./src/Maths/modulo.sol)
+    * [Multiply Array](./src/Maths/MulArray.sol)
+    * [Multiply Digit](./src/Maths/multiplyDigit.sol)
+    * [Percentage](./src/Maths/Percentage.sol)
+    * [Perfect Square](./src/Maths/perfectSquare.sol)
+    * [Sub Digit](./src/Maths/subDigit.sol)
+    * [Sum Digit](./src/Maths/subDigit.sol)
+    * [Volume](./src/Maths/volume.sol)
+    * [Zellers Congruence Algorithm](./src/Maths/zellersCongruenceAlgorithm.sol)
+  * [Searches](./src/Searchs)
+    * [Binary Search](./src/Searchs/BinarySearch.sol)
+  *[Sorts](./src/Sorts)
+    * [Bubble Sort](./src/Sorts/BubbleSort.sol)
+    * [Selection Sort](./src/Sorts/SelectionSort.sol)
+
+
+ ## Community Channels
 
 We're on [Discord](https://discord.gg/c7MnfGFGa6) and [Gitter](https://gitter.im/TheAlgorithms)! Community channels are great for you to ask questions and get help. Please join us!


### PR DESCRIPTION
I added the list of algorithms uploaded to the repository; if the inventory needs to be shifted to some new folder by the name of DIRECTORY.md, I can create one.

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/Solidity/pull/44"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

