### PR TITLE
Added stringMatching algorithm in Maths

### DIFF
--- a/src/Maths/stringMatch.sol
+++ b/src/Maths/stringMatch.sol
@@ -8,22 +8,24 @@ pragma solidity ^0.8.0;
  */
 
 contract StringMatch {
-   
     string firstString;
-string secondString;
- 
-   function setFirstString(string memory _firstString) public{
+    string secondString;
+
+    function setFirstString(string memory _firstString) public {
         firstString = _firstString;
-   }
+    }
 
-   function setSecondString(string memory _secondString) public{
-         secondString= _secondString;
-   }
+    function setSecondString(string memory _secondString) public {
+        secondString = _secondString;
+    }
 
-   function stringMatch()public view returns(bool){
-if (keccak256(abi.encodePacked(firstString)) == keccak256(abi.encodePacked(secondString))){
-    return true;
-}
-    return false;
-   }
+    function stringMatch() public view returns (bool) {
+        if (
+            keccak256(abi.encodePacked(firstString)) ==
+            keccak256(abi.encodePacked(secondString))
+        ) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/Maths/stringMatch.sol
+++ b/src/Maths/stringMatch.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+/**
+ * @title String Matching.
+ * @author Sreek  https://github.com/sreekar9601.
+ * @dev Contract to demonstrate matching of two strings.
+ */
+
+contract StringMatch {
+   
+    string firstString;
+string secondString;
+ 
+   function setFirstString(string memory _firstString) public{
+        firstString = _firstString;
+   }
+
+   function setSecondString(string memory _secondString) public{
+         secondString= _secondString;
+   }
+
+   function stringMatch()public view returns(bool){
+if (keccak256(abi.encodePacked(firstString)) == keccak256(abi.encodePacked(secondString))){
+    return true;
+}
+    return false;
+   }
+}


### PR DESCRIPTION
## Solidity code demonstration for string Matching
 The stringMatch function uses keccak256 as the '==' operator does not work on strings in solidity

made changes to Maths folder

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/Solidity/pull/51"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

