### PR TITLE
[TESTS] LinearSearch and Binary Search Tests

### DIFF
--- a/src/Searches/test/BinarySearch.t.sol
+++ b/src/Searches/test/BinarySearch.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../BinarySearch.sol";
+
+contract LinearSearchTest is Test {
+    // Target contract
+    BinarySearch bs;
+
+    /// Test Params
+    uint256[] private arr = [3, 4, 5, 7, 11, 12, 13, 14, 15, 20];
+    uint private key = 20;
+
+    //  =====   Set up  =====
+    function setUp() public {
+        bs = new BinarySearch();
+        bs.setValue(key);
+        bs.setArray(arr);
+    }
+    
+    /// @dev Test `BinarySearch`
+
+    function test_BinarySearch() external {
+        uint searchedIndex = bs.printResult();
+        uint expectedIndex = 9;
+        assertEq(expectedIndex, searchedIndex);
+    }
+}

--- a/src/Searches/test/BinarySearch.t.sol
+++ b/src/Searches/test/BinarySearch.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import "forge-std/Test.sol";
 import "../BinarySearch.sol";
 
-contract LinearSearchTest is Test {
+contract BinarySearchTest is Test {
     // Target contract
     BinarySearch bs;
 

--- a/src/Searches/test/LinearSearch.t.sol
+++ b/src/Searches/test/LinearSearch.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../LinearSearch.sol";
+
+contract LinearSearchTest is Test {
+    // Target contract
+    LinearSearch ls;
+
+    /// Test Params
+    uint256[] public arr = [12, 14, 11, 3, 15, 5, 4, 13, 7, 20];
+    uint private key = 4;
+
+    //  =====   Set up  =====
+    function setUp() public {
+        ls = new LinearSearch();
+    }
+
+    /// @dev Test `LinearSearch`
+
+    function test_LinearSearch() public {
+        int searchedIndex = ls.search(arr,key);
+        int expectedIndex = 6;
+        assertEq(expectedIndex, searchedIndex);
+    }
+}


### PR DESCRIPTION
This PR adds the foundry tests for the LinearSearch and BinarySearch Contracts.

Corresponding Issue: #57 

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/Solidity/pull/58"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

